### PR TITLE
fix language for code hightlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ with this package:
 
 Add the dependency to your `package.json`:
 
-```console
+```shell
 $ yarn add gatsby-source-s3-asset
 $ # Or:
 $ npm install --save gatsby-source-s3-asset


### PR DESCRIPTION
fix warning:

```
warn unable to find prism language 'console' for highlighting. applying generic code block
```